### PR TITLE
Don't through exception when HTML title is empty

### DIFF
--- a/extraction/__init__.py
+++ b/extraction/__init__.py
@@ -207,7 +207,7 @@ class Extractor(object):
         cleaned_results = {}
         for data_type, data_values in results.items():
             if data_type in self.text_types:
-                data_values = [self.cleanup_text(x) for x in data_values]
+                data_values = [self.cleanup_text(x) for x in filter(None, data_values)]
             if data_type in self.url_types:
                 data_values = [self.cleanup_url(x, source_url=source_url) for x in data_values]
 
@@ -218,7 +218,7 @@ class Extractor(object):
                     unique_values.append(data_value)
 
             cleaned_results[data_type] = unique_values
-        
+
         return cleaned_results
 
     def extract(self, html, source_url=None):

--- a/extraction/tests/data.py
+++ b/extraction/tests/data.py
@@ -146,3 +146,15 @@ HTML5_HTML = """
           </body>
         </html>
 """
+
+EMPTY_TITLE_HTML = """
+<html>
+  <head>
+    <title></title>
+  </head>
+  <body>
+    <h2>H2</h2>
+    <h1>H1</h1>
+    <h1>H1 2</h1>
+  </body>
+</html>"""

--- a/extraction/tests/tests.py
+++ b/extraction/tests/tests.py
@@ -119,6 +119,10 @@ class TestSequenceFunctions(unittest.TestCase):
         self.assertEqual(extracted.description, None)
         self.assertEqual(extracted.image, None)
 
+    def test_empty_title(self):
+        "Test that HTML with an empty title sets first h1 heading as title."
+        extracted = self.extractor.extract(EMPTY_TITLE_HTML)
+        self.assertEqual(extracted.title, "H1")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When extracting content from an HTML file with an empty title an exception occurs, see traceback below. To avoid this I added a call to filter to remove possible None values from data_values in the cleanup function. I also added a test.

```
Traceback (most recent call last):
  File "tests/tests.py", line 123, in test_empty_title
    extracted = self.extractor.extract(EMPTY_TITLE_HTML)
  File "/home/ramiro/repos/pub/bookmark-tools/local/lib/python2.7/site-packages/extraction/__init__.py", line 248, in extract
    return self.extracted_class(**self.cleanup(extracted, html, source_url=source_url))
  File "/home/ramiro/repos/pub/bookmark-tools/local/lib/python2.7/site-packages/extraction/__init__.py", line 211, in cleanup
    data_values = [self.cleanup_text(x) for x in data_values]
  File "/home/ramiro/repos/pub/bookmark-tools/local/lib/python2.7/site-packages/extraction/__init__.py", line 183, in cleanup_text
    return " ".join(value.split())
AttributeError: 'NoneType' object has no attribute 'split'
```
