### PR TITLE
make python3 compatible

### DIFF
--- a/extraction/__init__.py
+++ b/extraction/__init__.py
@@ -8,7 +8,10 @@ Retrieve and extract data from HTML documents.
     >>> resp = extr.extract(html)
     >>> print resp
 """
-import urlparse
+try:
+    import urlparse
+except ImportError:
+    from urllib import parse as urlparse
 import importlib
 
 


### PR DESCRIPTION
python2 standard library `urlparse` has been renamed to `urllib.parse` in python3. I changed import clause compatible throughout python2~python3.